### PR TITLE
chore: add autoapprove for patch and minor versions

### DIFF
--- a/package-rules.json
+++ b/package-rules.json
@@ -5,6 +5,21 @@
         "github-actions"
       ],
       "groupName": "github-actions"
+    },
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": true
+    },
+    {
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## what

- add automerge for patch and minors

## why

- reduce overhead of approvals

## additional
- this will need also https://github.com/apps/renovate-approve in every repo we want to use renovate
- adding branch exceptions/rules
- maybe we should consider https://docs.renovatebot.com/noise-reduction/#branch-automerging ?