### PR TITLE
chore: add major package rules

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -2,7 +2,6 @@ name: pre-commit
 
 on:
   pull_request:
-  push:
     branches: [main]
 
 jobs:

--- a/package-rules.json
+++ b/package-rules.json
@@ -13,7 +13,7 @@
         "https://github.com/"
       ],
       "prBodyDefinitions": {
-        "OpenSSF": "[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/{{sourceRepo}}/badge)](https://             securityscorecards.dev/viewer/?uri=github.com/{{sourceRepo}})"
+        "OpenSSF": "[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/{{sourceRepo}}/badge)](https://securityscorecards.dev/viewer/?uri=github.com/{{sourceRepo}})"
       },
       "prBodyColumns": [
         "Package",
@@ -36,6 +36,23 @@
         "devDependencies"
       ],
       "automerge": true
+    },
+    {
+      "groupName": "all major dependencies",
+      "groupSlug": "all-major",
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "prBodyColumns": [
+        "Package",
+        "Type",
+        "Update",
+        "Change",
+        "Pending"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- add major package rules
- fix url in openssf scorecard
- do not run pre-commit pipeline when merged to main, as it will fail