### PR TITLE
chore: add detection to _VERSION in dockerfiles and GHA

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,9 +4,12 @@
     "config:best-practices",
     ":separateMultipleMajorReleases",
     "schedule:daily",
+    "customManagers:dockerfileVersions",
+    "customManagers:githubActionsVersions",
     "github>coreruleset/renovate-config:labels",
     "github>coreruleset/renovate-config:security",
-    "github>coreruleset/renovate-config:package-rules"
+    "github>coreruleset/renovate-config:package-rules",
+    "github>coreruleset/renovate-config:custom-managers"
   ],
   "commitMessageSuffix": " in {{packageFile}}",
   "dependencyDashboardAutoclose": true


### PR DESCRIPTION
## what

- add detection to _VERSION variables in GHA or dockerfiles

## why

- updating extra versions