### PR TITLE
feat: delay dependency updates to reduce infection risk

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,9 @@ repos:
 
       # check yaml and json
       - id: check-json
+        exclude: '^default\.json$'
       - id: pretty-format-json
+        exclude: '^default\.json$'
         args:
           - "--autofix"
           - "--no-sort-keys"

--- a/default.json
+++ b/default.json
@@ -11,5 +11,13 @@
     "github>coreruleset/renovate-config:package-rules"
   ],
   "commitMessageSuffix": " in {{packageFile}}",
-  "dependencyDashboardAutoclose": true
+  "dependencyDashboardAutoclose": true,
+  // Delay dependency updates to reduce the risk of infected
+  // packages becoming active in our build pipelines.
+  // https://docs.renovatebot.com/key-concepts/minimum-release-age/
+  // https://docs.renovatebot.com/configuration-options/#await-x-time-duration-before-automerging
+  "minimumReleaseAge": "7 days",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
+  "internalChecksFilter": "strict",
+  "prCreation": "not-pending"
 }


### PR DESCRIPTION
The infection of Trivy showed that tools like Renovate can actually increase the infection risk. This PR configures Renovate to delay the creation of any dependency update PRs to reduce the risk of infection through malicious releases.

Note that not all update scenarios are yet supported by `minimumReleaseAge`.
Also note, that Renovate will still create PRs for security updates.